### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Magyar is a client-only React 19 + Vite + TypeScript SPA (Tailwind v4, shadcn/Radix UI). The only backend is a remote hosted **Supabase** project accessed with the anon key; there is no local backend/database to run and no auth.
+
+### Services / commands
+Single frontend service. Standard scripts live in `package.json`:
+- Dev server: `npm run dev` (Vite on `http://localhost:5173`). Use `npm run dev -- --host` if you need it reachable on the VM network interface.
+- Build: `npm run build` (`tsc -b` typecheck + `vite build`). <!-- pragma: allowlist secret -->
+- Lint: `npm run lint` (ESLint flat config).
+
+### Non-obvious notes
+- Package manager: both `package-lock.json` (npm) and `bun.lock` (bun) are committed. This environment uses **npm** (`npm install` / `npm ci`); pick one manager and stick with it to avoid lockfile drift.
+- Supabase credentials are provided as environment variables (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_SUPABASE_PUBLISHABLE_DEFAULT_KEY`) injected as Cloud Agent secrets — there is no committed `.env`. Vite reads them at dev/build time via `import.meta.env`. The Flash Cards feature (and only that feature) needs them; Conjugator, Grammar, and Phrasebook are fully local/static.
+- `npm run lint` currently reports pre-existing errors (in `src/components/ui/*` and `src/hooks/use-mobile.ts`) unrelated to environment setup — do not treat these as environment breakage.
+- The `import-anki` script (`npm run import-anki`) uses `better-sqlite3` (a native module) and is a maintenance tool, not part of the app runtime.
+- Flash Cards write to the shared remote Supabase `flashcards`/`review_logs` tables and upload images to the `cardimages` bucket — avoid creating/reviewing cards in tests unless you intend to mutate shared data. The Conjugator quiz is a safe, fully-local flow for end-to-end verification.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for the Magyar Hungarian language learning app (React 19 + Vite + TypeScript, remote Supabase backend).

- Installed dependencies with `npm install` (configured as the Cloud Agent update script).
- Added `AGENTS.md` with durable Cursor Cloud notes (single frontend service, standard scripts, Supabase-only backend via injected env vars, pre-existing lint errors, and safe end-to-end verification flow).

No application code was modified.

## Verification
- `npm run build` — passes (tsc typecheck + vite build).
- `npm run lint` — runs; reports pre-existing errors in `src/components/ui/*` and `src/hooks/use-mobile.ts` unrelated to setup.
- `npm run dev` — Vite serves `http://localhost:5173` (HTTP 200).
- Supabase reachability confirmed (REST read on `flashcards` → HTTP 200).
- Hello-world: completed a Conjugator quiz for the verb `lát` (present, indefinite) with all six conjugations graded correct.

[conjugator_quiz_demo.mp4](https://cursor.com/agents/bc-4d958fa6-a3aa-42f3-a896-28f7a9eeb3e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconjugator_quiz_demo.mp4)

[All six conjugations marked correct with green checkmarks](https://cursor.com/agents/bc-4d958fa6-a3aa-42f3-a896-28f7a9eeb3e6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconjugator_quiz_correct.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d958fa6-a3aa-42f3-a896-28f7a9eeb3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d958fa6-a3aa-42f3-a896-28f7a9eeb3e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

